### PR TITLE
Feat/functions-behaviour

### DIFF
--- a/agent/ingest_graph.py
+++ b/agent/ingest_graph.py
@@ -10,7 +10,7 @@ from langgraph_checkpoint_surrealdb import SurrealSaver
 from typing_extensions import TypedDict
 
 from agent.graph import _ensure_checkpoint_tables
-from ingestion.loader import get_db_client, load_file
+from ingestion.loader import get_db_client, load_calls, load_file
 from ingestion.parser import parse_file, parse_repo
 
 load_dotenv()
@@ -60,7 +60,20 @@ def _process_file(state: IngestionState) -> dict:
 def _has_more(state: IngestionState) -> str:
     processed = set(state.get("processed_files") or [])
     remaining = [f for f in (state.get("all_files") or []) if f not in processed]
-    return "process_file" if remaining else END
+    return "process_file" if remaining else "create_call_edges"
+
+
+def _create_call_edges(state: IngestionState) -> dict:
+    """Second-pass node: create calls edges after all files are ingested."""
+    parsed_files = parse_repo(state["repo_path"])
+
+    async def _load():
+        async with get_db_client() as db:
+            return await load_calls(parsed_files, db)
+
+    count = asyncio.run(_load())
+    print(f"Call edges created: {count}")
+    return {}
 
 
 def build_ingestion_agent():
@@ -78,8 +91,10 @@ def build_ingestion_agent():
     graph = StateGraph(IngestionState)
     graph.add_node("initialize", _initialize)
     graph.add_node("process_file", _process_file)
+    graph.add_node("create_call_edges", _create_call_edges)
     graph.set_entry_point("initialize")
-    graph.add_conditional_edges("initialize", _has_more, {"process_file": "process_file", END: END})
-    graph.add_conditional_edges("process_file", _has_more, {"process_file": "process_file", END: END})
+    graph.add_conditional_edges("initialize", _has_more, {"process_file": "process_file", "create_call_edges": "create_call_edges"})
+    graph.add_conditional_edges("process_file", _has_more, {"process_file": "process_file", "create_call_edges": "create_call_edges"})
+    graph.add_edge("create_call_edges", END)
 
     return graph.compile(checkpointer=checkpointer)

--- a/demo/seed_demo.py
+++ b/demo/seed_demo.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from surrealdb import AsyncSurreal
 
-from ingestion.loader import get_db_client, load_file
+from ingestion.loader import get_db_client, load_calls, load_file
 from ingestion.parser import parse_repo
 
 load_dotenv()
@@ -82,20 +82,27 @@ async def ingest(repo_path: str) -> None:
 async def main() -> None:
     print("=== Demo seed starting ===\n")
 
-    print("Step 1/3: Resetting database ...")
+    print("Step 1/4: Resetting database ...")
     await reset_database()
 
-    print("\nStep 2/3: Ingesting demo repo ...")
+    print("\nStep 2/4: Ingesting demo repo ...")
     await ingest(DEMO_REPO)
 
-    print("\nStep 3/3: Verifying counts ...")
+    print("\nStep 3/4: Creating call edges ...")
+    parsed_files = parse_repo(DEMO_REPO)
+    async with get_db_client() as db:
+        call_edge_count = await load_calls(parsed_files, db)
+    print(f"Call edges: {call_edge_count}")
+
+    print("\nStep 4/4: Verifying counts ...")
     counts = await verify_counts()
 
     print(
         f"\nDemo ready. "
         f"Files: {counts['files']} | "
         f"Functions: {counts['functions']} | "
-        f"Classes: {counts['classes']}"
+        f"Classes: {counts['classes']} | "
+        f"Call edges: {call_edge_count}"
     )
 
 

--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -178,3 +178,57 @@ async def load_file(parsed: dict, db: AsyncSurreal, repo_path: str | None = None
         edge_count += 1
 
     return {"functions": fn_count, "classes": class_count, "edges": edge_count}
+
+
+# ---------------------------------------------------------------------------
+# Second-pass: create calls edges across all ingested files
+# ---------------------------------------------------------------------------
+
+async def load_calls(parsed_files: list[dict], db: AsyncSurreal) -> int:
+    """Create function→calls→function edges for all parsed files (second pass).
+
+    Must be called after all files are loaded so callee nodes already exist.
+    Returns the number of edges created.
+    """
+    # Collect all unique callee names referenced across every function
+    all_callee_names: set[str] = set()
+    for parsed in parsed_files:
+        for fn in parsed.get("functions", []):
+            all_callee_names.update(fn.get("calls") or [])
+
+    if not all_callee_names:
+        return 0
+
+    # Batch-fetch all function nodes whose names match any callee
+    rows = await db.query(
+        "SELECT id, name FROM `function` WHERE name IN $names",
+        {"names": list(all_callee_names)},
+    )
+    # Unwrap SurrealDB response format
+    if isinstance(rows, list) and rows and isinstance(rows[0], dict) and "result" in rows[0]:
+        rows = rows[0].get("result") or []
+
+    # Build name → list of bare record IDs (strip "function:abc123" → "abc123")
+    callee_map: dict[str, list[str]] = {}
+    for row in (rows or []):
+        name = row.get("name")
+        rid = str(row.get("id", ""))
+        bare = rid.split(":")[-1] if ":" in rid else rid
+        if name and bare:
+            callee_map.setdefault(name, []).append(bare)
+
+    edge_count = 0
+    for parsed in parsed_files:
+        file_path = parsed["path"]
+        for fn in parsed.get("functions", []):
+            caller_bare = _function_id(file_path, fn.get("class_name"), fn["name"])
+            for callee_name in (fn.get("calls") or []):
+                for callee_bare in callee_map.get(callee_name, []):
+                    eid = _edge_id(caller_bare, "calls", callee_bare)
+                    await db.query(
+                        "INSERT RELATION INTO calls { id: type::record('calls', $eid), in: type::record('function', $caller), out: type::record('function', $callee) } ON DUPLICATE KEY UPDATE in = in",
+                        {"eid": eid, "caller": caller_bare, "callee": callee_bare},
+                    )
+                    edge_count += 1
+
+    return edge_count

--- a/ingestion/parser.py
+++ b/ingestion/parser.py
@@ -17,6 +17,7 @@ def parse_file(path: str) -> dict:
                 "lineno": node.lineno,
                 "docstring": ast.get_docstring(node),
                 "class_name": None,
+                "calls": _extract_calls(node),
             })
 
         elif isinstance(node, ast.ClassDef):
@@ -38,6 +39,7 @@ def parse_file(path: str) -> dict:
                         "lineno": child.lineno,
                         "docstring": ast.get_docstring(child),
                         "class_name": node.name,
+                        "calls": _extract_calls(child),
                     })
 
     for node in ast.walk(tree):
@@ -55,6 +57,17 @@ def parse_file(path: str) -> dict:
         "classes": classes,
         "imports": list(dict.fromkeys(imports)),
     }
+
+
+def _extract_calls(fn_node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    calls = []
+    for n in ast.walk(fn_node):
+        if isinstance(n, ast.Call):
+            if isinstance(n.func, ast.Name):
+                calls.append(n.func.id)
+            elif isinstance(n.func, ast.Attribute):
+                calls.append(n.func.attr)
+    return list(dict.fromkeys(calls))
 
 
 def _dotted(node: ast.Attribute) -> str:

--- a/ingestion/seed.py
+++ b/ingestion/seed.py
@@ -1,7 +1,7 @@
 import argparse
 import asyncio
 
-from ingestion.loader import get_db_client, load_file
+from ingestion.loader import get_db_client, load_calls, load_file
 from ingestion.parser import parse_repo
 
 
@@ -20,11 +20,16 @@ async def seed(repo_path: str) -> None:
             for k in totals:
                 totals[k] += counts[k]
 
+    print("Creating call edges ...")
+    async with get_db_client() as db:
+        call_edges = await load_calls(files, db)
+
     print(
         f"\nDone. Files processed: {total} | "
         f"Functions processed: {totals['functions']} | "
         f"Classes processed: {totals['classes']} | "
-        f"Edges processed: {totals['edges']} "
+        f"Edges processed: {totals['edges']} | "
+        f"Call edges: {call_edges} "
         f"(DB deduplicates by name+file — stored count will be lower)"
     )
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -94,69 +94,76 @@ def _get_rows(result) -> list:
     return []
 
 
-def _build_agraph(repos, folders, files, fns, classes, contains_raw, folder_edges_raw, repo_edges_raw, calls_raw) -> tuple[list, list]:
+def _build_agraph(
+    repos, folders, files, fns, classes,
+    contains_raw, folder_edges_raw, repo_edges_raw, calls_raw,
+    *,
+    show_repos: bool = True,
+    show_folders: bool = True,
+    show_files: bool = True,
+    show_functions: bool = True,
+    show_classes: bool = True,
+    show_structural: bool = True,
+    show_calls: bool = True,
+) -> tuple[list, list]:
     nodes: list[Node] = []
     edges: list[Edge] = []
     seen: set[str] = set()
 
-    for row in _get_rows(repos):
-        nid = str(row.get("id", ""))
-        label = str(row.get("name", ""))
-        if nid and nid not in seen:
-            nodes.append(Node(id=nid, label=label, color=REPO_COLOR, size=35))
-            seen.add(nid)
+    if show_repos:
+        for row in _get_rows(repos):
+            nid = str(row.get("id", ""))
+            label = str(row.get("name", ""))
+            if nid and nid not in seen:
+                nodes.append(Node(id=nid, label=label, color=REPO_COLOR, size=35))
+                seen.add(nid)
 
-    for row in _get_rows(folders):
-        nid = str(row.get("id", ""))
-        label = str(row.get("path", "")).split("/")[-1] or str(row.get("path", ""))
-        if nid and nid not in seen:
-            nodes.append(Node(id=nid, label=label, color=FOLDER_COLOR, size=25))
-            seen.add(nid)
+    if show_folders:
+        for row in _get_rows(folders):
+            nid = str(row.get("id", ""))
+            label = str(row.get("path", "")).split("/")[-1] or str(row.get("path", ""))
+            if nid and nid not in seen:
+                nodes.append(Node(id=nid, label=label, color=FOLDER_COLOR, size=25))
+                seen.add(nid)
 
-    for row in _get_rows(files):
-        nid = str(row.get("id", ""))
-        label = Path(str(row.get("path", ""))).name
-        if nid and nid not in seen:
-            nodes.append(Node(id=nid, label=label, color=FILE_COLOR, size=20))
-            seen.add(nid)
+    if show_files:
+        for row in _get_rows(files):
+            nid = str(row.get("id", ""))
+            label = Path(str(row.get("path", ""))).name
+            if nid and nid not in seen:
+                nodes.append(Node(id=nid, label=label, color=FILE_COLOR, size=20))
+                seen.add(nid)
 
-    for row in _get_rows(fns):
-        nid = str(row.get("id", ""))
-        label = str(row.get("name", ""))
-        if nid and nid not in seen:
-            nodes.append(Node(id=nid, label=label, color=FUNC_COLOR, size=12))
-            seen.add(nid)
+    if show_functions:
+        for row in _get_rows(fns):
+            nid = str(row.get("id", ""))
+            label = str(row.get("name", ""))
+            if nid and nid not in seen:
+                nodes.append(Node(id=nid, label=label, color=FUNC_COLOR, size=12))
+                seen.add(nid)
 
-    for row in _get_rows(classes):
-        nid = str(row.get("id", ""))
-        label = str(row.get("name", ""))
-        if nid and nid not in seen:
-            nodes.append(Node(id=nid, label=label, color=CLASS_COLOR, size=15))
-            seen.add(nid)
+    if show_classes:
+        for row in _get_rows(classes):
+            nid = str(row.get("id", ""))
+            label = str(row.get("name", ""))
+            if nid and nid not in seen:
+                nodes.append(Node(id=nid, label=label, color=CLASS_COLOR, size=15))
+                seen.add(nid)
 
-    for row in _get_rows(contains_raw):
-        src = str(row.get("in", ""))
-        dst = str(row.get("out", ""))
-        if src and dst and src in seen and dst in seen:
-            edges.append(Edge(source=src, target=dst))
+    if show_structural:
+        for raw in (contains_raw, folder_edges_raw, repo_edges_raw):
+            for row in _get_rows(raw):
+                src = str(row.get("in", ""))
+                dst = str(row.get("out", ""))
+                if src and dst and src in seen and dst in seen:
+                    edges.append(Edge(source=src, target=dst))
 
-    for row in _get_rows(folder_edges_raw):
-        src = str(row.get("in", ""))
-        dst = str(row.get("out", ""))
-        if src and dst and src in seen and dst in seen:
-            edges.append(Edge(source=src, target=dst))
-
-    for row in _get_rows(repo_edges_raw):
-        src = str(row.get("in", ""))
-        dst = str(row.get("out", ""))
-        if src and dst and src in seen and dst in seen:
-            edges.append(Edge(source=src, target=dst))
-
-    for row in _get_rows(calls_raw):
-        src = str(row.get("in", ""))
-        dst = str(row.get("out", ""))
-        if src and dst and src in seen and dst in seen:
-            edges.append(Edge(source=src, target=dst, color=CALLS_EDGE_COLOR))
+    if show_calls:
+        for row in _get_rows(calls_raw):
+            src = str(row.get("in", ""))
+            dst = str(row.get("out", ""))
+            if src and dst and src in seen and dst in seen:
+                edges.append(Edge(source=src, target=dst, color=CALLS_EDGE_COLOR))
 
     return nodes, edges
 
@@ -171,6 +178,15 @@ def _init_state() -> None:
         "ingest_stop_event": None,
         "ingest_thread_id": None,
         "ingest_progress": {"processed": 0, "total": 0, "status": "idle"},
+        # Graph filter defaults
+        "gf_repos": True,
+        "gf_folders": True,
+        "gf_files": True,
+        "gf_functions": True,
+        "gf_classes": True,
+        "gf_structural": True,
+        "gf_calls": True,
+        "graph_frozen": False,
     }
     for key, val in defaults.items():
         if key not in st.session_state:
@@ -273,6 +289,18 @@ with st.sidebar:
         st.caption("Ready. Enter a repo path and click **Ingest**.")
 
     st.divider()
+    with st.expander("Graph filters", expanded=False):
+        st.caption("Nodes")
+        st.session_state.gf_repos      = st.checkbox("Repos",      value=st.session_state.gf_repos)
+        st.session_state.gf_folders    = st.checkbox("Folders",    value=st.session_state.gf_folders)
+        st.session_state.gf_files      = st.checkbox("Files",      value=st.session_state.gf_files)
+        st.session_state.gf_functions  = st.checkbox("Functions",  value=st.session_state.gf_functions)
+        st.session_state.gf_classes    = st.checkbox("Classes",    value=st.session_state.gf_classes)
+        st.caption("Edges")
+        st.session_state.gf_structural = st.checkbox("Structural (contains / folder / repo)", value=st.session_state.gf_structural)
+        st.session_state.gf_calls      = st.checkbox("Calls",      value=st.session_state.gf_calls)
+
+    st.divider()
     st.caption("🔴 repo  🟠 folder  🔵 file  🟣 function  🟢 class  🟠→ calls")
 
 
@@ -282,36 +310,47 @@ tab_graph, tab_chat = st.tabs(["Knowledge Graph", "Ask the Codebase"])
 
 # ── Tab 1: Knowledge Graph ─────────────────────────────────────────────────
 with tab_graph:
-    if st.button("Refresh graph", type="primary"):
+    ctrl_col, freeze_col = st.columns([3, 2])
+    with ctrl_col:
+        refresh_clicked = st.button("Refresh graph", type="primary")
+    with freeze_col:
+        freeze = st.checkbox("Freeze layout", value=st.session_state.graph_frozen, key="graph_frozen")
+
+    if refresh_clicked:
         try:
             with st.spinner("Loading graph from SurrealDB…"):
-                repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges, calls_edges = _fetch_graph_data()
-            nodes, edges = _build_agraph(repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges, calls_edges)
-            st.session_state["graph_nodes"] = nodes
-            st.session_state["graph_edges"] = edges
+                st.session_state["graph_data_raw"] = _fetch_graph_data()
             st.session_state.pop("graph_error", None)
         except Exception as exc:
             st.session_state["graph_error"] = str(exc)
-            st.session_state.pop("graph_nodes", None)
+            st.session_state.pop("graph_data_raw", None)
         st.rerun()
 
     if "graph_error" in st.session_state:
         st.error(f"Could not load graph: {st.session_state['graph_error']}")
-    elif "graph_nodes" in st.session_state:
-        g_nodes: list = st.session_state["graph_nodes"]
-        g_edges: list = st.session_state["graph_edges"]
+    elif "graph_data_raw" in st.session_state:
+        g_nodes, g_edges = _build_agraph(
+            *st.session_state["graph_data_raw"],
+            show_repos=st.session_state.gf_repos,
+            show_folders=st.session_state.gf_folders,
+            show_files=st.session_state.gf_files,
+            show_functions=st.session_state.gf_functions,
+            show_classes=st.session_state.gf_classes,
+            show_structural=st.session_state.gf_structural,
+            show_calls=st.session_state.gf_calls,
+        )
         if g_nodes:
             st.caption(f"{len(g_nodes)} nodes · {len(g_edges)} edges")
             cfg = Config(
                 width="100%",
                 height=620,
                 directed=True,
-                physics=True,
+                physics=not freeze,
                 hierarchical=False,
             )
             agraph(nodes=g_nodes, edges=g_edges, config=cfg)
         else:
-            st.info("No nodes in the database yet. Run ingestion first, then refresh.")
+            st.info("No nodes match the current filters.")
     else:
         st.info("Click **Refresh graph** to load the knowledge graph.")
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -16,6 +16,7 @@ FOLDER_COLOR = "#F39C12"  # orange
 FILE_COLOR = "#4C8BF5"   # blue
 FUNC_COLOR = "#9B59B6"   # purple
 CLASS_COLOR = "#27AE60"  # green
+CALLS_EDGE_COLOR = "#E67E22"  # dark orange
 
 
 # ── Background ingestion thread ────────────────────────────────────────────
@@ -78,7 +79,8 @@ def _fetch_graph_data() -> tuple:
             contains_edges = await db.query("SELECT in, out FROM contains LIMIT 5000")
             folder_edges = await db.query("SELECT in, out FROM in_folder LIMIT 5000")
             repo_edges = await db.query("SELECT in, out FROM in_repo LIMIT 5000")
-        return repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges
+            calls_edges = await db.query("SELECT in, out FROM calls LIMIT 5000")
+        return repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges, calls_edges
 
     return asyncio.run(_query())
 
@@ -92,7 +94,7 @@ def _get_rows(result) -> list:
     return []
 
 
-def _build_agraph(repos, folders, files, fns, classes, contains_raw, folder_edges_raw, repo_edges_raw) -> tuple[list, list]:
+def _build_agraph(repos, folders, files, fns, classes, contains_raw, folder_edges_raw, repo_edges_raw, calls_raw) -> tuple[list, list]:
     nodes: list[Node] = []
     edges: list[Edge] = []
     seen: set[str] = set()
@@ -149,6 +151,12 @@ def _build_agraph(repos, folders, files, fns, classes, contains_raw, folder_edge
         dst = str(row.get("out", ""))
         if src and dst and src in seen and dst in seen:
             edges.append(Edge(source=src, target=dst))
+
+    for row in _get_rows(calls_raw):
+        src = str(row.get("in", ""))
+        dst = str(row.get("out", ""))
+        if src and dst and src in seen and dst in seen:
+            edges.append(Edge(source=src, target=dst, color=CALLS_EDGE_COLOR))
 
     return nodes, edges
 
@@ -265,7 +273,7 @@ with st.sidebar:
         st.caption("Ready. Enter a repo path and click **Ingest**.")
 
     st.divider()
-    st.caption("🔴 repo  🟠 folder  🔵 file  🟣 function  🟢 class")
+    st.caption("🔴 repo  🟠 folder  🔵 file  🟣 function  🟢 class  🟠→ calls")
 
 
 # ── Main tabs ──────────────────────────────────────────────────────────────
@@ -277,8 +285,8 @@ with tab_graph:
     if st.button("Refresh graph", type="primary"):
         try:
             with st.spinner("Loading graph from SurrealDB…"):
-                repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges = _fetch_graph_data()
-            nodes, edges = _build_agraph(repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges)
+                repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges, calls_edges = _fetch_graph_data()
+            nodes, edges = _build_agraph(repos, folders, files, fns, classes, contains_edges, folder_edges, repo_edges, calls_edges)
             st.session_state["graph_nodes"] = nodes
             st.session_state["graph_edges"] = edges
             st.session_state.pop("graph_error", None)


### PR DESCRIPTION
## Summary

- Add static AST call analysis to the parser: each function now carries a `calls` list of callee names extracted by walking `ast.Call` nodes
- Add `load_calls()`: a second-pass loader that batch-resolves callee names to function record IDs and upserts `function → calls → function` edges, guaranteeing all nodes exist before edges are created
- Wire the second pass into all ingestion paths: `seed.py`, `seed_demo.py`, and a new `create_call_edges` terminal node in the LangGraph ingestion agent
- Render `calls` edges in the graph UI as dark orange arrows, visually separating behavioural relationships from structural ones (contains/in_folder/in_repo)