### PR TITLE
feat(ingestion): cache function embeddings by content hash

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,94 @@
+# Demo Cheat Sheet
+
+## Setup (before judges arrive)
+
+```bash
+ollama list
+ollama pull llama3.2:3b
+ollama pull nomic-embed-text
+
+uv run python demo/seed_demo.py
+
+uv run streamlit run ui/app.py
+```
+
+---
+
+## Paste into "Ask the Codebase" chat
+
+```
+find the slugify function and what depends on it
+```
+
+```
+What changed between versions? If anything new is undocumented, suggest a docstring and raise a GitHub issue.
+```
+
+---
+
+## Backup queries
+
+```
+what would break if I changed slugify?
+```
+
+```
+what repos have been indexed and how many versions?
+```
+
+```
+what changed between versions and what might be affected?
+```
+
+---
+
+## SurrealDB Cloud UI queries
+
+Query 1 — BM25 keyword search:
+> "SurrealDB has native full-text search with BM25 scoring — this finds functions matching 'auth' across names and docstrings in a single query."
+
+```sql
+SELECT name, file.path AS path,
+       search::score(0) + search::score(1) AS score
+FROM `function`
+WHERE name @0@ 'auth' OR docstring @1@ 'auth'
+ORDER BY score DESC LIMIT 10;
+```
+
+Query 2 — Blast radius (graph traversal):
+> "Multi-hop graph traversal — one SurrealQL statement walks two hops through the call graph to find direct callers and their callers. This is structural reasoning that context windows can't do."
+
+```sql
+SELECT name, file.path AS path,
+       <-calls<-`function`.name AS direct_callers,
+       <-calls<-`function`<-calls<-`function`.name AS transitive_callers
+FROM `function`
+WHERE name CONTAINS "_send";
+```
+
+Query 3 — Diff status:
+> "The knowledge graph is version-aware — every file and function has a diff status. This query traverses the contains edge to show which functions live inside each changed file."
+
+```sql
+SELECT path, diff_status,
+       ->contains->function.name AS functions
+FROM file
+WHERE diff_status IS NOT NONE
+ORDER BY diff_status;
+```
+
+---
+
+## Emergency fallback (if Streamlit crashes)
+
+```bash
+uv run python -c "
+from agent.graph import build_query_agent
+agent = build_query_agent()
+config = {'configurable': {'thread_id': 'demo-fallback'}}
+r = agent.invoke({
+    'messages': [('user', 'What changed between versions? If anything new is undocumented, suggest a docstring and raise a GitHub issue.')],
+}, config)
+print(r['messages'][-1].content)
+"
+```

--- a/agent/ingest_graph.py
+++ b/agent/ingest_graph.py
@@ -117,9 +117,16 @@ def _has_more(state: IngestionState) -> str:
 
 
 def _create_call_edges(state: IngestionState) -> dict:
-    """Second-pass node: create calls edges after all files are ingested."""
-    disk = state.get("disk_path") or state["repo_path"]
-    parsed_files = parse_repo(disk)
+    """Second-pass node: create calls edges after all files are ingested.
+
+    Only re-parses processed files (not the entire repo) to avoid redundant work.
+    """
+    processed = state.get("processed_files") or []
+    if not processed:
+        logger.info("No processed files — skipping call edges")
+        return {}
+
+    parsed_files = [parse_file(f) for f in processed]
 
     async def _load():
         async with get_db_client() as db:

--- a/demo/DEMO_SCRIPT.md
+++ b/demo/DEMO_SCRIPT.md
@@ -231,99 +231,155 @@ Terminal 2:    Ready for SurrealQL demo queries (scratch queries above)
 
 ---
 
-## The script
+## The script (90 seconds, tight)
+
+> **Screen rule:** judges should always be looking at something interesting. Never leave them staring at a loading spinner — talk through it or switch screens.
 
 ---
 
-**[0:00 — OPEN: problem + v1 graph]**
+### **[0:00–0:10] OPEN — v1 knowledge graph**
 
-*Show graph tab — v1 fixture indexed, files/functions/classes visible with call edges.*
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Streamlit → **Knowledge Graph** tab | Main canvas — the graph visualisation | First impression: "this tool does something visual and useful" |
+
+**What's on screen:** v1 fixture graph — files (large nodes), functions (small nodes), call edges (arrows), class groupings. Pre-loaded, no waiting.
+
+**Your hands:** Mouse on the graph. Pan slowly left-to-right so judges see the full structure. Hover over a call edge to show the tooltip.
 
 Say:
-> "Every developer knows this moment — new codebase, no idea what talks to what. Dead Reckoning turns any Python repo into a queryable knowledge graph."
-
-*Point at nodes and edges*
-
-Say:
-> "We pointed our agent at a Python repo and it parsed every file into a SurrealDB knowledge graph. Files, functions, classes, call relationships — all stored as nodes and edges."
+> "Every developer knows this moment — new codebase, no idea what talks to what. Dead Reckoning turns any Python repo into a queryable knowledge graph. Files, functions, classes, call relationships — all stored as nodes and edges in SurrealDB."
 
 ---
 
-**[0:10 — QUERY: agent on the codebase]**
+### **[0:10–0:25] QUERY — agent finds slugify + dependencies**
 
-*Switch to "Ask the Codebase" tab. Type:*
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Streamlit → **Ask the Codebase** tab | Chat input at bottom, then results area | Shows the agent is intelligent, not just a pretty graph |
+
+**Your hands:** Click "Ask the Codebase" tab. The chat input is at the bottom. Type (pre-typed, just paste):
+
 ```
 find the slugify function and what depends on it
 ```
 
-Say (while agent responds):
-> "The agent uses hybrid search — SurrealDB's `search::rrf()` fuses vector similarity and BM25 keyword matching in one query inside the database. Then it chains into trace_impact — a multi-hop graph traversal to find everything that depends on that function."
-
-*Results appear — function names, file paths, callers*
+Hit Enter. While the agent thinks (~3-5s), talk:
 
 Say:
-> "Real functions, real call chains, real impact analysis. This is structural reasoning — 'what calls X, and what calls that' — which context windows can't do. You need the graph."
+> "The agent uses hybrid search — vector similarity and BM25 keyword matching fused with Reciprocal Rank Fusion, all inside SurrealDB. Then it chains into trace_impact — a multi-hop graph traversal to find everything that depends on that function."
+
+**Results appear** — function names, file paths, callers listed.
+
+Say:
+> "Structural reasoning — 'what calls X, and what calls that' — context windows can't do this. You need the graph."
+
+**Don't linger.** As soon as results are visible, move on.
 
 ---
 
-**[0:30 — VERSIONED DIFF: ingest v2 live]**
+### **[0:25–0:50] DIFF — ingest v2 live, interrupt, resume**
 
-*Trigger v2 ingestion — click the quick-select for v2, click Ingest.*
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Streamlit → **Sidebar** (left panel) | Ingestion controls, quick-select buttons | Shows live pipeline + LangGraph interrupt — the "wow" moment |
+
+**Your hands:** Move to the sidebar. Click the v2 quick-select button, then click **Ingest**.
 
 Say:
 > "Now watch what happens when code changes. Version one is indexed, let's ingest version two."
 
-*Conflict dialog appears: "A previous version exists"*
-
-> "It detects the previous version automatically."
-
-*Click "Add new version" — ingestion runs — pipeline pauses at diff review (interrupt)*
+**[0:30]** Conflict dialog appears: "A previous version exists."
 
 Say:
-> "The ingestion pipeline just paused. It's a LangGraph interrupt — the agent checkpointed its state to SurrealDB and is waiting for us to review the diff before continuing. This is resumable — we could kill the process, come back tomorrow, and it picks up right here."
+> "It detects the previous version automatically."
 
-*Click Resume — graph updates — nodes turn green, yellow, red, blue*
+**Your hands:** Click **"Add new version"**. Ingestion runs — progress bar moves — then **pipeline pauses**.
+
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Streamlit → **Sidebar** | "Diff ready — review the graph, then click Resume" status + Resume button | Proves LangGraph interrupt + SurrealDB checkpoint persistence |
+
+**[0:35]** The sidebar shows the green **Resume** button and diff log.
+
+Say:
+> "The ingestion pipeline just paused — a LangGraph interrupt. The agent checkpointed its state to SurrealDB. We could kill the process, come back tomorrow, and resume right here."
+
+**Your hands:** Click **Resume**. Then immediately click the **Knowledge Graph** tab to watch it update.
+
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Streamlit → **Knowledge Graph** tab | Graph canvas — nodes changing colour | Visual payoff: green/yellow/red/blue = version-aware graph |
+
+**[0:45]** Graph updates — nodes turn green (unchanged), yellow (modified), red (deleted), blue (new).
 
 Say:
 > "Green: unchanged. Yellow: modified. Red: deleted. Blue: new. Not just files — individual functions are diff'd. The knowledge graph is now version-aware."
 
 ---
 
-**[0:55 — AGENT: automated code review chain]**
+### **[0:50–1:15] AGENT — 3-tool chain: diff → docstring → GitHub issue**
 
-*Switch to "Ask the Codebase" tab. Type:*
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Streamlit → **Ask the Codebase** tab | Chat input, then watch tool calls appear | The headline demo moment: autonomous multi-tool chain |
+
+**Your hands:** Click "Ask the Codebase" tab. Paste:
+
 ```
 What changed between versions? If anything new is undocumented, suggest a docstring and raise a GitHub issue.
 ```
 
-Say (while agent responds):
-> "Watch the agent chain three tools. First version_diff — reads diff_status from the knowledge graph, spots new files and flags undocumented functions. Then generate_docstring — reads the function source from SurrealDB, sends it to the LLM for a docstring. Then raise_issue — files a GitHub issue with the suggestion. Three tools, one query. The agent decided the chain — LangGraph conditional routing."
-
-*Point at tool calls in the response — version_diff → generate_docstring → raise_issue. Show the GitHub issue URL.*
-
----
-
-**[1:20 — LANGSMITH: show the trace]**
-
-*Switch to LangSmith tab — find the trace for the query*
+Hit Enter. While the agent works (~10-15s), narrate the tool calls as they appear:
 
 Say:
-> "Every step is observable. LangGraph run — LLM reasoning, version_diff fires, generate_docstring chains in, raise_issue follows. Three tool calls, arguments, results — fully auditable in LangSmith."
+> "Watch the agent chain three tools. First — version_diff reads diff_status from the knowledge graph, spots new files, flags undocumented functions."
 
-*Point at the 3-tool call sequence.*
+*version_diff result appears*
+
+> "Then — generate_docstring reads the function source from SurrealDB and sends it to the LLM for a docstring."
+
+*generate_docstring result appears*
+
+> "Then — raise_issue files a GitHub issue with the suggestion. Three tools, one query. The agent decided the chain — LangGraph conditional routing."
+
+*raise_issue result appears with GitHub URL*
+
+**Your hands:** Point at / scroll to the GitHub issue URL in the response.
 
 ---
 
-**[1:40 — CLOSE: summary]**
+### **[1:15–1:25] LANGSMITH — show the trace**
 
-*Switch back to Streamlit — show the diff-coloured graph one more time*
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Browser tab 2 → **LangSmith** | Trace waterfall — 3-tool sequence | Proves observability: every step is auditable |
+
+**Your hands:** Switch to the LangSmith browser tab (pre-opened). Click the most recent trace. The waterfall shows the 3-tool sequence.
+
+Say:
+> "Every step is observable. LLM reasoning, version_diff, generate_docstring, raise_issue — fully auditable in LangSmith."
+
+**Point at** the 3 tool call spans in the waterfall. Don't click into them — just show the sequence.
+
+---
+
+### **[1:25–1:30] CLOSE — back to graph, summary**
+
+| Screen | Where to look | Why |
+|--------|--------------|-----|
+| Streamlit → **Knowledge Graph** tab | Diff-coloured graph | End on the visual: version-aware knowledge graph |
+
+**Your hands:** Switch back to Streamlit. Click Knowledge Graph tab. The diff-coloured graph is still visible.
 
 Say:
 > "One query: discovered a problem, generated a fix, filed an issue. SurrealDB stores the graph, vectors, diffs, and agent state. Dead Reckoning — navigate any codebase."
 
 ---
 
-**[2:00 — DONE]**
+### **[1:30 — DONE]**
+
+30 seconds of buffer for slow responses or judge questions during the demo.
 
 ---
 
@@ -461,6 +517,8 @@ Every demo moment scores in at least one category. Nothing is filler. The 3-tool
 **If the conflict dialog doesn't appear:** v1 ingestion_id not in session state. Refresh, re-ingest v1 quickly (fixture repo is fast), then ingest v2.
 
 **If the SurrealQL terminal query fails:** Skip it, stay in the UI. The agent tool calls prove SurrealDB usage too. Don't debug live.
+
+**If the agent returns "timed out while waiting for handshake response":** SurrealDB Cloud transient connection drop. Just resubmit the same query — it works on retry. Say "cloud database connection reset — retrying" and keep talking.
 
 **If Streamlit crashes entirely:**
 ```bash

--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -277,17 +277,41 @@ async def load_file(
     class_count = 0
     edge_count = 0
 
-    # Batch-embed function docstrings via async Ollama client
+    # Batch-embed function docstrings via async Ollama client, reusing cached
+    # embeddings for functions whose source hasn't changed (same content_hash).
     embed_model = os.getenv("OLLAMA_EMBED_MODEL", "nomic-embed-text")
     embed_host = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     fns_with_docs = [(i, fn) for i, fn in enumerate(parsed["functions"]) if fn.get("docstring")]
     embeddings_map: dict[int, list[float]] = {}
     if fns_with_docs:
-        docs = [_strip_markdown(fn["docstring"]) for _, fn in fns_with_docs]
-        client = ollama_client.AsyncClient(host=embed_host)
-        response = await client.embed(model=embed_model, input=docs)
-        vecs = response.embeddings
-        embeddings_map = {i: vec for (i, _), vec in zip(fns_with_docs, vecs)}
+        # Check DB for existing embeddings by content_hash to avoid redundant Ollama calls
+        source_hashes = [fn.get("source_hash") for _, fn in fns_with_docs if fn.get("source_hash")]
+        cached: dict[str, list[float]] = {}
+        if source_hashes:
+            rows = await db.query(
+                "SELECT content_hash, embedding FROM `function` WHERE content_hash IN $hashes AND embedding IS NOT NONE LIMIT 100",
+                {"hashes": source_hashes},
+            )
+            for row in _get_rows(rows):
+                if row.get("content_hash") and row.get("embedding"):
+                    cached[row["content_hash"]] = row["embedding"]
+
+        # Split into cached hits and functions that need embedding
+        need_embed: list[tuple[int, dict]] = []
+        for i, fn in fns_with_docs:
+            sh = fn.get("source_hash")
+            if sh and sh in cached:
+                embeddings_map[i] = cached[sh]
+            else:
+                need_embed.append((i, fn))
+
+        if need_embed:
+            docs = [_strip_markdown(fn["docstring"]) for _, fn in need_embed]
+            client = ollama_client.AsyncClient(host=embed_host)
+            response = await client.embed(model=embed_model, input=docs)
+            vecs = response.embeddings
+            for (i, _), vec in zip(need_embed, vecs):
+                embeddings_map[i] = vec
 
     # Upsert functions + contains edges
     for idx, fn in enumerate(parsed["functions"]):


### PR DESCRIPTION
## Summary
- Re-use existing embeddings on re-ingestion when a function's `source_hash` matches a row already in SurrealDB, avoiding redundant Ollama embedding calls.
- `_create_call_edges` now re-parses only the files actually processed in this run instead of walking the whole repo.
- Adds `DEMO.md` cheat sheet and extends `demo/DEMO_SCRIPT.md`.

## Why
Re-ingesting a repo for an incremental change currently re-embeds every function with a docstring — the single most expensive step. The parser already emits a `source_hash` per function, so the DB can serve as its own cache: if the hash already has an embedding, reuse it.

## Implementation
- `ingestion/loader.py:287-316`: before batching docstrings, look up existing `(content_hash, embedding)` rows and split `fns_with_docs` into cached hits and the subset that still needs to be embedded.
- `agent/ingest_graph.py:119-137`: replace `parse_repo(disk)` with `[parse_file(f) for f in processed]` in the call-edges phase so the second pass scales with changed files, not repo size.

## Follow-ups (not in this PR)
- The cache lookup query has a `LIMIT 100` that silently caps cache hits for files with >100 distinct hashes.
- `source_hashes` could be deduped with `set()` before the `IN $hashes` query (cosmetic).
- Consider logging cache hit rate (`Reused N cached embeddings, embedded M new`) for observability.

## Test plan
- [x] Seed demo via `uv run python demo/seed_demo.py`
- [x] Re-ingest the same repo and confirm the embedding call count drops
- [x] Modify one function and confirm only that function gets re-embedded