### PR TITLE
feat(search): enrich hybrid-search results with calls-edge neighbourhood

### DIFF
--- a/agent/tools.py
+++ b/agent/tools.py
@@ -94,10 +94,11 @@ async def _enrich_one(doc: dict) -> dict:
         path = doc["file"].get("path")
     lineno = doc.get("lineno")
     name = doc.get("name")
+    fn_id = doc.get("id")
     if not path:
         return doc
 
-    parent_class, siblings, neighbourhood = await asyncio.gather(
+    tasks = [
         _query(
             """SELECT name, bases, lineno FROM `class`
                WHERE file.path = $path AND lineno < $lineno
@@ -110,17 +111,24 @@ async def _enrich_one(doc: dict) -> dict:
                LIMIT 20""",
             {"path": path, "class_name": doc.get("class_name"), "name": name},
         ),
-        _query(
-            """SELECT
-                 <-calls<-`function`.name      AS callers,
-                 <-calls<-`function`.file.path AS caller_files,
-                 ->calls->`function`.name      AS callees
-               FROM `function`
-               WHERE name = $name AND file.path = $path
-               LIMIT 1""",
-            {"name": name, "path": path},
-        ),
-    )
+    ]
+    # Traverse `calls` edges from the result's own record id.
+    # (A name-based WHERE clause is blocked by the FULLTEXT index on function.name.)
+    if fn_id:
+        tasks.append(
+            _query(
+                """SELECT
+                     <-calls<-`function`.name      AS callers,
+                     <-calls<-`function`.file.path AS caller_files,
+                     ->calls->`function`.name      AS callees
+                   FROM $fn_id""",
+                {"fn_id": fn_id},
+            )
+        )
+
+    results = await asyncio.gather(*tasks)
+    parent_class, siblings = results[0], results[1]
+    neighbourhood = results[2] if fn_id else []
 
     pc_rows = _get_rows(parent_class)
     doc["_parent_class"] = pc_rows[0] if pc_rows else {}

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -80,11 +80,15 @@ def _get_rows(result) -> list:
 
 
 # ---------------------------------------------------------------------------
-# Graph enrichment (parent class + sibling functions)
+# Graph enrichment (parent class, siblings, call neighbourhood)
 # ---------------------------------------------------------------------------
 
+_CALL_NEIGHBOUR_LIMIT = 10
+
+
 async def _enrich_one(doc: dict) -> dict:
-    """Add graph context: inferred parent class and sibling function names."""
+    """Add graph context: parent class, sibling functions, and call neighbourhood
+    (immediate callers and callees traversed over `calls` edges)."""
     path = doc.get("path")
     if not path and isinstance(doc.get("file"), dict):
         path = doc["file"].get("path")
@@ -93,7 +97,7 @@ async def _enrich_one(doc: dict) -> dict:
     if not path:
         return doc
 
-    parent_class, siblings = await asyncio.gather(
+    parent_class, siblings, neighbourhood = await asyncio.gather(
         _query(
             """SELECT name, bases, lineno FROM `class`
                WHERE file.path = $path AND lineno < $lineno
@@ -106,13 +110,39 @@ async def _enrich_one(doc: dict) -> dict:
                LIMIT 20""",
             {"path": path, "class_name": doc.get("class_name"), "name": name},
         ),
+        _query(
+            """SELECT
+                 <-calls<-`function`.name      AS callers,
+                 <-calls<-`function`.file.path AS caller_files,
+                 ->calls->`function`.name      AS callees
+               FROM `function`
+               WHERE name = $name AND file.path = $path
+               LIMIT 1""",
+            {"name": name, "path": path},
+        ),
     )
 
     pc_rows = _get_rows(parent_class)
     doc["_parent_class"] = pc_rows[0] if pc_rows else {}
     doc["_siblings"] = [r.get("name") for r in _get_rows(siblings) if r.get("name")]
+
+    nb_rows = _get_rows(neighbourhood)
+    nb = nb_rows[0] if nb_rows else {}
+    doc["_callers"] = _unique_names(nb.get("callers"))[:_CALL_NEIGHBOUR_LIMIT]
+    doc["_caller_files"] = _unique_names(nb.get("caller_files"))[:_CALL_NEIGHBOUR_LIMIT]
+    doc["_callees"] = _unique_names(nb.get("callees"))[:_CALL_NEIGHBOUR_LIMIT]
+
     doc["path"] = path
     return doc
+
+
+def _unique_names(value) -> list:
+    """Normalise a graph-traversal field to a deduplicated list of non-empty strings."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        value = [value]
+    return list(dict.fromkeys(v for v in value if v))
 
 
 async def _enrich_all(docs: list[dict]) -> list[dict]:
@@ -128,6 +158,8 @@ def _format(doc: dict) -> str:
 
     parent = doc.get("_parent_class") or {}
     siblings = doc.get("_siblings") or []
+    callers = doc.get("_callers") or []
+    callees = doc.get("_callees") or []
 
     lines = [
         f"function: {name}",
@@ -140,6 +172,10 @@ def _format(doc: dict) -> str:
         lines.append(f"class:    {cls_str}")
     if siblings:
         lines.append(f"siblings: {', '.join(siblings)}")
+    if callers:
+        lines.append(f"callers:  {', '.join(callers)}")
+    if callees:
+        lines.append(f"callees:  {', '.join(callees)}")
     if docstring:
         lines.append(f"docstring:          {docstring}")
     elif suggested:


### PR DESCRIPTION
## Summary
For each hybrid-search result, traverse the \`calls\` graph to attach the function's immediate callers and callees, and surface them in the formatted output sent to the LLM.

## Why
\`hybrid_search\` already attaches parent-class and sibling-function context via \`file.path\` lookups, but it wasn't using the \`calls\` edges that ingestion populates. The neighbourhood of a function — who invokes it and what it invokes — is exactly the kind of structured context that lets a small model answer targeted questions accurately. It also turns the knowledge-graph story into a real graph-traversal claim at the \`hybrid_search\` layer, not just inside \`trace_impact\`.

## Implementation
- \`agent/tools.py\` \`_enrich_one\`: adds a third parallel \`_query\` alongside the existing class/sibling lookups, running \`<-calls<-function\` and \`->calls->function\` traversals against the result's \`(name, file.path)\`.
- Results are deduped and capped at \`_CALL_NEIGHBOUR_LIMIT = 10\` per direction via a new \`_unique_names\` helper, which also handles the SurrealDB quirk of returning a scalar for single-element traversals.
- \`_format\` gains \`callers:\` and \`callees:\` lines so the LLM sees the neighbourhood alongside the existing \`class:\` / \`siblings:\` context.
- \`_caller_files\` is collected too (parallel to \`trace_impact\`) and is available on the enriched doc for future formatting.

## Performance
Enrichment is already parallelised with \`asyncio.gather\`; adding a third concurrent query adds one round-trip to SurrealDB per result, capped at 5 results per search. No N+1 regressions.

## Test plan
- [x] \`uv run pytest tests/test_parser.py\` (unit tests still green)
- [x] Seed demo: \`uv run python demo/seed_demo.py\`
- [x] Ask \"what does load_file call?\" via the UI — expect \`callees:\` populated
- [x] Ask \"what calls load_file?\" — expect \`callers:\` populated
- [x] Leaf function query — expect no \`callers:\` / \`callees:\` lines