### PR TITLE
fix(ingestion): populate calls edges by filtering client-side

### DIFF
--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -405,11 +405,15 @@ async def load_calls(parsed_files: list[dict], db: AsyncSurreal, ingestion_id: s
 
     # --- Function calls edges ---
     if all_callee_names:
-        # Batch-fetch all function nodes whose names match any callee
-        rows = await db.query(
-            "SELECT id, name FROM `function` WHERE name IN $names",
-            {"names": list(all_callee_names)},
-        )
+        # Fetch all function nodes in this ingestion and filter in Python.
+        # A direct `WHERE name IN $names` clause is intercepted by the BM25
+        # FULLTEXT index on function.name and returns zero rows.
+        query = "SELECT id, name FROM `function`"
+        params: dict = {}
+        if ingestion_id:
+            query += " WHERE ingestion_id = $iid"
+            params["iid"] = ingestion_id
+        rows = await db.query(query, params)
         # Unwrap SurrealDB response format
         if isinstance(rows, list) and rows and isinstance(rows[0], dict) and "result" in rows[0]:
             rows = rows[0].get("result") or []
@@ -418,6 +422,8 @@ async def load_calls(parsed_files: list[dict], db: AsyncSurreal, ingestion_id: s
         callee_map: dict[str, list[str]] = {}
         for row in (rows or []):
             name = row.get("name")
+            if name not in all_callee_names:
+                continue
             rid = str(row.get("id", ""))
             bare = rid.split(":")[-1] if ":" in rid else rid
             if name and bare:


### PR DESCRIPTION
## Summary
\`load_calls\` has been silently producing zero \`calls\` edges. Seed output reporting \"Call edges: N\" is misleading — N is the \`imports\` count (the \`edge_count\` counter is shared with the imports loop below). \`trace_impact\` always returned \"leaf function\" on a freshly seeded demo.

## Root cause
The callee lookup was:

\`\`\`sql
SELECT id, name FROM \`function\` WHERE name IN \$names
\`\`\`

The BM25 FULLTEXT index on \`function.name\` (\`fn_name_ft\`, defined in \`ingestion/schema.surql\`) intercepts equality comparisons on that column and returns zero rows. \`CONTAINS\` and \`@@\` still work, but \`=\` and \`IN\` do not. The query returned empty, \`callee_map\` was empty, and the inner insert loop never ran.

Reproduced on a fresh seed:

\`\`\`
callee names: {'paginate', 'slugify', 'create_user', ...}
matched functions: 0 []
load_calls returned: 3   ← imports edges, not calls
calls count after: 0
\`\`\`

## Fix
Scope the fetch by \`ingestion_id\` (unaffected by FULLTEXT intercept) and filter the name-to-id map in Python. For a single ingestion the row count is bounded by the number of functions in that ingestion, so this is not a meaningful perf regression and keeps the cross-ingestion scoping intact.

After the fix, the same seed run produces:
\`\`\`
calls: 5
contains: 13
imports: 3
\`\`\`

## Test plan
- [x] \`uv run python demo/seed_demo.py\`
- [x] Inspect \`SELECT count() FROM calls GROUP ALL\` — expect >0
- [x] Run \`trace_impact('paginate')\` — expect a direct caller

## Follow-up (not in this PR)
The \`edge_count\` variable in \`load_calls\` is still shared between the calls loop and the imports loop, so the seed-script log \"Call edges: N\" conflates both. Worth splitting into two counters for honest reporting.