### PR TITLE
fix(ui): auto-refresh sidebar while ingestion is active

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import threading
+import time
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -1127,6 +1128,13 @@ with st.sidebar:
             st.error(f"Error: {p.get('error', 'unknown')}")
         else:
             st.caption("Ready. Enter a repo path and click **Ingest**.")
+
+        # Auto-refresh while ingestion is active so background state changes
+        # (progress updates, interrupt flip to awaiting_resume, completion)
+        # surface in the UI without the user needing to click anything.
+        if status in ("running", "awaiting_resume", "stopping"):
+            time.sleep(1)
+            st.rerun()
 
         # ── Diff log ───────────────────────────────────────────────────
         log = list(st.session_state.diff_status_log)


### PR DESCRIPTION
## Summary
The ingestion pipeline runs in a background thread that writes to \`st.session_state.ingest_progress\`. The main Streamlit script only re-runs on user interaction, so background state transitions (progress updates, interrupt flip to \`awaiting_resume\`, completion) never surfaced in the UI. Most visibly: the **Resume** button for the diff-review interrupt never appeared — the server-side thread set \`progress[\"status\"] = \"awaiting_resume\"\` and blocked on an event, but the browser showed stale \"Running...\" state forever.

## Repro
1. Seed v1: \`uv run python demo/seed_demo.py\`
2. Start UI: \`uv run streamlit run ui/app.py\`
3. Sidebar → Quick select → v2 → Ingest
4. Click \"Add new version\" in the conflict dialog
5. Watch the sidebar: log stops at \`Discovering files...\`, Resume button never appears

Server-side log shows:
\`\`\`
Graph state.next = ('review_diff',)
Diff review interrupt hit — waiting for user to resume
\`\`\`
but the UI is oblivious.

## Fix
Add a one-second poll-and-rerun at the bottom of the Ingestion expander when \`status\` is in \`{running, awaiting_resume, stopping}\`:

\`\`\`python
if status in (\"running\", \"awaiting_resume\", \"stopping\"):
    time.sleep(1)
    st.rerun()
\`\`\`

Stops polling automatically once ingestion transitions to \`done\`/\`error\`/\`idle\`, so there's no idle-state CPU burn.

## Verified
- Full demo run via Playwright: seed → ingest v2 → conflict dialog → Add new version → diff-review interrupt surfaces correctly → **Resume** button appears → click → files stream → \`Edges created: calls=6 imports=3\` → UI transitions to \`done\`.
- Multi-tool chain query still works end-to-end afterwards (\`version_diff\` → \`generate_docstring\` → \`raise_issue\` creates real GitHub issue #21).

## Alternatives considered
- \`st_autorefresh\` component — extra dep, overkill for a one-line fix.
- \`@st.fragment(run_every=\"1s\")\` — requires restructuring the sidebar into a fragment, not worth the churn.