### PR TITLE
docs(readme): add end-to-end demo walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,93 @@ uv run python demo/seed_demo.py --with-v2
 
 ---
 
+## Demo walkthrough (3 minutes)
+
+A scripted end-to-end tour you can run locally. Uses the included `tests/fixtures/sample_repo/v1` and `v2` so it works offline, no external repo required.
+
+> **Model note:** tool calling requires a model that produces structured tool calls reliably. Small models (including `llama3.2:3b`) tend to emit tool invocations as plain text instead of calling them. For this walkthrough set `OLLAMA_MODEL=gpt-oss:20b` in your `.env`.
+
+### 1. Seed the v1 fixture
+
+```bash
+uv run python demo/seed_demo.py
+uv run streamlit run ui/app.py
+```
+
+Open `http://localhost:8501`. The **Knowledge Graph** tab shows `18 nodes · 25 edges` — files, functions, classes, and `calls` / `contains` / `in_repo` / `imports` edges from the v1 fixture.
+
+### 2. Query 1 — hybrid search + graph traversal
+
+Click the **Ask the Codebase** tab and send:
+
+```
+find the slugify function and what depends on it
+```
+
+The agent runs `hybrid_search` (HNSW vector + BM25 keyword fused with `search::rrf()`), then chains into `trace_impact` to walk `<-calls<-function` edges. You get back:
+
+- **Location:** `tests/fixtures/sample_repo/v1/utils.py`
+- **Direct callers:** `display_items` (in `main.py`)
+- **Transitive callers:** `run` (in `main.py` calls `display_items`, which calls `slugify`)
+
+The right-hand **Context Graph** panel shows the retrieved nodes.
+
+### 3. Ingest v2 live — checkpoint + resume
+
+In the sidebar, open **Quick select** → click **v2 — sample repo (with changes)** → click **Ingest**.
+
+A **"Repo already ingested"** dialog appears. Click **Add new version**.
+
+The ingestion pipeline parses v2, creates a snapshot, computes the diff against v1, and then **pauses at a LangGraph interrupt** — the sidebar shows *"Diff ready — review the graph, then click Resume"* with a **Resume** button.
+
+This is SurrealDB's checkpointer in action: the ingestion agent's state is persisted. Kill the process, come back, and it resumes from the same point.
+
+Click **Resume**. v2 files stream in, call edges are rebuilt, the knowledge graph updates to `34 nodes · 47 edges` with diff colours: **red** (deleted), **yellow** (modified), **purple** (new), **green** (unchanged).
+
+### 4. Query 2 — the hero multi-tool chain
+
+Back on **Ask the Codebase**, send:
+
+```
+What changed between versions? If anything new is undocumented, suggest a docstring and raise a GitHub issue.
+```
+
+The agent autonomously chains three tools:
+
+1. **`version_diff`** — reads `diff_status` from the versioned graph. Reports deleted `models.py`, modified `utils.py`, new undocumented `Item.__repr__`.
+2. **`generate_docstring`** — reads the function source from SurrealDB, sends it to the LLM, returns a Python docstring.
+3. **`raise_issue`** — opens a real GitHub issue via `gh issue create` with the suggestion.
+
+Expected output ends with a clickable **"Issue: Add missing docstring for Item.__repr__"** link.
+
+### 5. Inspect the LangSmith trace
+
+Open your LangSmith project (default: `dead-reckoning`). The most recent trace shows the full waterfall:
+
+```
+LangGraph
+├── llm (ChatOllama gpt-oss:20b)
+├── tools → version_diff
+├── llm (ChatOllama gpt-oss:20b)
+├── tools → hybrid_search
+│   ├── embed_query      (Ollama embedding call)
+│   ├── rrf_retrieve     (SurrealDB HNSW + BM25 + search::rrf)
+│   └── graph_enrich     (parent class + siblings + calls-edge traversal)
+├── tools → generate_docstring
+└── tools → raise_issue
+```
+
+Every retrieval stage, every LLM call, and the full reasoning chain is visible as nested spans. This is the observability surface for debugging hybrid search quality: when a query returns the wrong answer, you open the trace and identify which stage failed.
+
+### Troubleshooting
+
+- **Agent emits tool calls as plain text** (e.g., `{"name": "slugify", "parameters": {}}`) — your model isn't producing structured tool calls. Switch to `gpt-oss:20b` or another tool-use-capable model.
+- **Resume button doesn't appear during v2 ingestion** — pull the latest `main`; this was a race condition fixed in [#22](https://github.com/atwmarshall/dead-reckoning/pull/22).
+- **`calls` count is 0 after seeding** — pull the latest `main`; `load_calls` had a silent failure fixed in [#18](https://github.com/atwmarshall/dead-reckoning/pull/18).
+- **`gh issue create` fails** — run `gh auth login` first.
+
+---
+
 ## Repo structure
 
 ```


### PR DESCRIPTION
## Summary
Adds a scripted 3-minute demo walkthrough to \`README.md\` so a blog reader (or anyone cloning the repo) can reproduce the full agent experience end-to-end using the included fixtures. Replaces the lost \`DEMO.md\` / \`demo/DEMO_SCRIPT.md\` content with something public-facing rather than judge-facing.

## Contents
- Model requirement note (\`gpt-oss:20b\` vs the default \`llama3.2:3b\`, which emits tool calls as plain text)
- Step-by-step: seed v1 → Query 1 (hybrid search + trace impact) → live v2 ingest → checkpoint/resume interrupt → Query 2 (the 3-tool chain) → LangSmith inspection
- Expected outputs for every step so a reader knows what \"working\" looks like
- A LangSmith waterfall diagram matching what they'll see in the trace
- Troubleshooting for the three issues I hit while testing this via Playwright:
  - Agent emits tool calls as text → switch model
  - Resume button never appears → fixed in #22
  - \`calls\` count is 0 → fixed in #18

## Base
This branch includes the commits from #19 (\`chore/pre-blog-polish\`). Merging #19 first will leave only the walkthrough commit here. If #19 is merged first, rebase this branch on \`main\` before merging.

## Verified
The walkthrough was **run end-to-end via Playwright against a clean seed**. Screenshots captured at \`.playwright-mcp/demo-0{1..9}-*.png\`:
- Knowledge Graph post-seed (v1, 18 nodes)
- Query 1 result with direct + transitive callers
- Conflict dialog → Diff ready / Resume button (the polling fix from #22)
- Diff-coloured graph (34 nodes, 47 edges)
- Multi-tool chain thinking
- Final answer with docstring + GitHub issue link (real issue #21 was created)
- LangSmith waterfall showing \`version_diff\` → \`hybrid_search\` → \`embed_query\` / \`rrf_retrieve\` / \`graph_enrich\` nested spans

## Known caveat
The walkthrough recommends \`gpt-oss:20b\`, which is ~13GB — not every reader will have it. Consider adding a lightweight alternative model in a follow-up.