### PR TITLE
fix(ingestion): remove LIMIT cap on embedding cache lookup

### DIFF
--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -289,7 +289,7 @@ async def load_file(
         cached: dict[str, list[float]] = {}
         if source_hashes:
             rows = await db.query(
-                "SELECT content_hash, embedding FROM `function` WHERE content_hash IN $hashes AND embedding IS NOT NONE LIMIT 100",
+                "SELECT content_hash, embedding FROM `function` WHERE content_hash IN $hashes AND embedding IS NOT NONE",
                 {"hashes": source_hashes},
             )
             for row in _get_rows(rows):


### PR DESCRIPTION
## Summary
- The embedding-reuse cache silently capped at `LIMIT 100` rows. Files with more than 100 functions sharing distinct content hashes would re-embed the excess on every ingest.
- Removing the limit lets the cache lookup return all matching rows; the `IN $hashes` predicate is already bounded by the input list.

## Test plan
- [x] Re-ingest fixture repo: cache hits unchanged for small repos.
- [x] Re-ingest a large repo (>100 functions) and verify Ollama call count drops on second run.

Closes #24