### PR TITLE
feat(ingestion): log embedding cache hit rate per file

### DIFF
--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -313,6 +313,9 @@ async def load_file(
             for (i, _), vec in zip(need_embed, vecs):
                 embeddings_map[i] = vec
 
+        reused = len(fns_with_docs) - len(need_embed)
+        print(f"  Embeddings: reused {reused} cached, embedded {len(need_embed)} new")
+
     # Upsert functions + contains edges
     for idx, fn in enumerate(parsed["functions"]):
         class_name = fn.get("class_name")


### PR DESCRIPTION
## Summary
- Adds a one-line per-file log showing how many function embeddings were reused from the cache vs freshly embedded via Ollama.
- Makes the cache effectiveness observable from the ingestion stream — useful both as a perf signal and as a quotable number for the blog.

## Test plan
- [x] First-run ingest: line reads `reused 0 cached, embedded N new`.
- [x] Second-run ingest of unchanged repo: line reads `reused N cached, embedded 0 new`.

Closes #25