### PR TITLE
fix(agent): align GITHUB_REPO default with .env.example

### DIFF
--- a/agent/tools.py
+++ b/agent/tools.py
@@ -560,7 +560,7 @@ def generate_docstring(function_name: str, file_path: str = "") -> str:
 def raise_issue(title: str, body: str) -> str:
     """Create a GitHub issue with a code improvement suggestion.
     Pass a title and markdown body. Use after generate_docstring to file the suggestion."""
-    repo = os.getenv("GITHUB_REPO", "archiemarshall/dead-reckoning")
+    repo = os.getenv("GITHUB_REPO", "atwmarshall/dead-reckoning")
 
     result = subprocess.run(
         ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body],


### PR DESCRIPTION
## Summary
- The fallback in `agent/tools.py` pointed at `archiemarshall/dead-reckoning`, which doesn't exist; `.env.example` already used the correct `atwmarshall/dead-reckoning`.
- Anyone running the `raise_issue` tool without setting `GITHUB_REPO` in their environment would hit a 404 from `gh issue create`.

## Test plan
- [x] `grep` confirms both files now use `atwmarshall/dead-reckoning`.
- [x] Run the multi-tool chain (`version_diff` → `generate_docstring` → `raise_issue`) without a `GITHUB_REPO` env var and verify the issue is created against the correct repo.

Closes #26