### PR TITLE
chore(env): default OLLAMA_MODEL to gemma4:e2b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ SURREALDB_DB=deadreckoning
 
 # Ollama (must be running locally — ollama.com)
 OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=llama3.2:3b           # swap to gpt-oss:20b for demo day
+OLLAMA_MODEL=gemma4:e2b            # ~7GB, produces clean structured tool calls. Older small models (e.g. llama3.2:3b) work but can occasionally emit malformed tool calls; gpt-oss:20b is a heavier fallback.
 OLLAMA_EMBED_MODEL=nomic-embed-text
 
 # GitHub (for raise_issue tool)

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ uv venv
 uv sync
 
 # 2. Pull Ollama models
-ollama pull llama3.2:3b       # LLM for dev/testing
-ollama pull nomic-embed-text # embeddings
+ollama pull gemma4:e2b        # LLM — clean tool calling at ~7GB
+ollama pull nomic-embed-text  # embeddings
 
 # 3. Configure environment
 cp .env.example .env
@@ -134,7 +134,7 @@ uv run python demo/seed_demo.py --with-v2
 
 A scripted end-to-end tour you can run locally. Uses the included `tests/fixtures/sample_repo/v1` and `v2` so it works offline, no external repo required.
 
-> **Model note:** tool calling requires a model that produces structured tool calls reliably. Small models (including `llama3.2:3b`) tend to emit tool invocations as plain text instead of calling them. For this walkthrough set `OLLAMA_MODEL=gpt-oss:20b` in your `.env`.
+> **Model note:** the default is now `gemma4:e2b` (~7 GB) — recent enough to produce clean structured tool calls and small enough to run on a laptop. Older small models such as `llama3.2:3b` will work most of the time but can occasionally emit tool calls as plain text or with malformed arguments, which trips up the multi-tool chain in step 4. If you hit that, fall back to `gpt-oss:20b`.
 
 ### 1. Seed the v1 fixture
 


### PR DESCRIPTION
## Summary
Bumps the default Ollama model from `llama3.2:3b` to `gemma4:e2b` (~7 GB).

`llama3.2:3b` mostly works but occasionally produces tool calls as plain text or with malformed arguments, which can break the multi-tool chain in step 4 of the walkthrough. `gemma4:e2b` is recent enough to emit clean structured tool calls every time we tested, while still being small enough to run on a laptop. Verified end-to-end against the live tool schemas (`hybrid_search`, `trace_impact`, `version_diff`, `generate_docstring`, `raise_issue`) — args match the schemas, no hallucinated tool names, no plain-text leakage.

`gpt-oss:20b` remains documented as a heavier fallback for anyone who hits issues.

Touches `.env.example`, the README quickstart `ollama pull` line, and the model note inside the demo walkthrough.

Closes #30