### PR TITLE
feat(readme): add tech stack badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # DeadReckoning
 
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776AB?logo=python&logoColor=white)](https://python.org)
+[![SurrealDB](https://img.shields.io/badge/SurrealDB-FF00A0?logo=surrealdb&logoColor=white)](https://surrealdb.com)
+[![LangGraph](https://img.shields.io/badge/LangGraph-1C3C3C?logo=langchain&logoColor=white)](https://langchain-ai.github.io/langgraph/)
+[![LangSmith](https://img.shields.io/badge/LangSmith-1C3C3C?logo=langchain&logoColor=white)](https://smith.langchain.com)
+[![Ollama](https://img.shields.io/badge/Ollama-000000?logo=ollama&logoColor=white)](https://ollama.com)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 > Navigate any codebase. Dead reckoning — finding your way through unknown territory.
 
 `dead-reckoning` parses any Python codebase into a **SurrealDB knowledge graph** — files, functions, classes, imports, and call relationships all become queryable nodes and edges. A **LangGraph agent** with six specialised tools navigates the graph to answer architecture questions in plain English. Every tool call, graph traversal, and reasoning step is traced in **LangSmith**. Ingestion is **checkpointed** — kill it mid-run, restart, and it resumes exactly where it stopped.


### PR DESCRIPTION
## Summary
- Add shields.io badges for Python, SurrealDB, LangGraph, LangSmith, Ollama, and MIT license
- Badges link to official project pages

## Test plan
- [x] Verify badges render on GitHub