### PR TITLE
fix(db): context graph missing standalone function nodes

### DIFF
--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -318,7 +318,7 @@ async def load_file(
 
     # Upsert functions + contains edges
     for idx, fn in enumerate(parsed["functions"]):
-        class_name = fn.get("class_name")
+        class_name = fn.get("class_name") or ""
         fnid = _function_id(path, class_name, fn["name"], ingestion_id)
         await db.query(
             """UPSERT type::record('function', $id) SET
@@ -336,7 +336,7 @@ async def load_file(
                 "docstring": fn.get("docstring"),
                 "has_docstring": bool(fn.get("docstring")),
                 "class_name": class_name,
-                "is_method": class_name is not None,
+                "is_method": bool(class_name),
                 "embedding": embeddings_map.get(idx),
                 "iid": ingestion_id,
                 "ch": fn.get("source_hash"),
@@ -436,7 +436,7 @@ async def load_calls(parsed_files: list[dict], db: AsyncSurreal, ingestion_id: s
         for parsed in parsed_files:
             file_path = parsed["path"]
             for fn in parsed.get("functions", []):
-                caller_bare = _function_id(file_path, fn.get("class_name"), fn["name"], ingestion_id)
+                caller_bare = _function_id(file_path, fn.get("class_name") or "", fn["name"], ingestion_id)
                 for callee_name in (fn.get("calls") or []):
                     for callee_bare in callee_map.get(callee_name, []):
                         eid = _edge_id(caller_bare, "calls", callee_bare)

--- a/ingestion/schema.surql
+++ b/ingestion/schema.surql
@@ -47,7 +47,7 @@ DEFINE FIELD IF NOT EXISTS file          ON `function` TYPE record<file>;
 DEFINE FIELD IF NOT EXISTS lineno        ON `function` TYPE int;
 DEFINE FIELD IF NOT EXISTS docstring     ON `function` TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS has_docstring ON `function` TYPE bool DEFAULT false;
-DEFINE FIELD IF NOT EXISTS class_name    ON `function` TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS class_name    ON `function` TYPE string DEFAULT "";
 DEFINE FIELD IF NOT EXISTS is_method     ON `function` TYPE bool DEFAULT false;
 DEFINE FIELD IF NOT EXISTS embedding      ON `function` TYPE option<array>;
 DEFINE FIELD IF NOT EXISTS ingestion_id   ON `function` TYPE string;
@@ -57,6 +57,7 @@ DEFINE FIELD IF NOT EXISTS source            ON `function` TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS suggested_docstring ON `function` TYPE option<string>;
 
 REMOVE INDEX IF EXISTS fn_name_file_class_idx ON TABLE `function`;
+UPDATE `function` SET class_name = "" WHERE class_name IS NONE;
 DEFINE INDEX fn_name_file_class_iid_idx ON `function` FIELDS name, file, class_name, ingestion_id UNIQUE;
 
 -- CLASS: a class definition


### PR DESCRIPTION
## Summary
- Fixes the context graph in "Ask the Codebase" showing only class methods (e.g. `to_dict`) while missing all standalone functions (e.g. `slugify`, `run`, `hash_password`)
- **Root cause**: SurrealDB's composite UNIQUE index on `(name, file, class_name, ingestion_id)` breaks equality lookups (`WHERE name = X`) when `class_name` is `NONE`. The query planner routes through the index but can't match records with `NONE` in an indexed field. Only methods (which have `class_name` set to e.g. `"User"`) were returned.

## Changes
- **schema.surql**: Changed `class_name` from `option<string>` to `string DEFAULT ""`, added migration `UPDATE` to backfill existing `NONE` values
- **loader.py**: Pass `""` instead of `None` for standalone functions during ingestion, update `is_method` check accordingly

## Verification
- Before fix: `SELECT name FROM function WHERE name IN $names` returned 1/5 functions
- After fix: returns 5/5 functions
- All 37 tests pass, 3 skipped (pre-existing)
- Function ID hashes are stable (`_function_id` already used `class_name or ""`)

## Test plan
- [x] Run `uv run python ingestion/apply_schema.py` on existing DB — standalone functions should become queryable
- [x] Run `uv run python demo/seed_demo.py`, ask about `slugify` — context graph should show slugify, run, hash_password etc.
- [x] Re-ingest a repo and verify all function nodes appear in the context graph